### PR TITLE
docs: getting-started: add subpath to volume mount

### DIFF
--- a/docs/flask/Acornfile
+++ b/docs/flask/Acornfile
@@ -31,7 +31,7 @@ containers: {
     }
     dirs: {
       if !args.dev {
-        "/var/lib/postgresql/data": "volume://pgdata"
+        "/var/lib/postgresql/data": "volume://pgdata?subpath=data"
       }
     }
     files: {


### PR DESCRIPTION
As per Acorn issue #557